### PR TITLE
Fix up crash present in the latest release

### DIFF
--- a/SIT.Launcher/MainWindow.xaml.cs
+++ b/SIT.Launcher/MainWindow.xaml.cs
@@ -54,7 +54,10 @@ namespace SIT.Launcher
             await UpdateInstallFromOfficial();
 
 
+            //ArchangelWTF: This function makes people crash due to it not being fully finished yet, only run in debug for now.
+#if DEBUG
             DisplayLatestLogs();
+#endif
         }
 
         public static readonly DependencyProperty SITReleasesProperty = DependencyProperty.Register("SITReleases", typeof(ObservableCollection<Release>), typeof(MainWindow), new FrameworkPropertyMetadata(null));


### PR DESCRIPTION
Title, this is present in the latest release if the log folder does not exist in the main EFT directory.. This bypasses that for now (As the function is not used anyway)